### PR TITLE
updating to point to the usr/local/bin/npm version to check and update.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,6 @@ class node_versioning (
         command   => "npm install -gf npm@${npm_version}",
         user      => root,
         provider  => shell,
-        onlyif    => "[ \"`npm -v`\" != \"${npm_version}\" ]",
+        onlyif    => "[ \"`/usr/local/bin/npm -v`\" != \"${npm_version}\" ]",
     }
 }


### PR DESCRIPTION
There was an issue where the `npm -v` for the local user wasn't updating to the newer version that was specified. This ensures that the `npm` that is used by the local user is updated by root.
